### PR TITLE
Fix memory leak.

### DIFF
--- a/harfbuzz/src/hb-ot-face.cc
+++ b/harfbuzz/src/hb-ot-face.cc
@@ -33,7 +33,10 @@ const char *rb_face_get_table_data(const rb_face_t *face, rb_tag_t tag, unsigned
 {
     rb_blob_t* blob = face->reference_table(tag);
     *len = blob->length;
-    return blob->data;
+    const char *data = blob->data;
+    // This blob was just pointing into it's parent's data, so we don't need it.
+    rb_blob_destroy(blob);
+    return data;
 }
 }
 


### PR DESCRIPTION
The function `rb_face_get_table_data` referenced table data, which creates a new shallow subblob. This blob was never destroyed though. The function is used in `crate::ot::get_table_data` and that's in turn used to get the table data in all places where we just receive a `rb_face_t` without a `ttfp_face`. Since the blob is just a shallow subblob it's pointer stays valid even when we destroy it. This is obviously a bit of a hack, but the whole `get_table_data` is a workaround anyway.