### PR TITLE
Improve OpenType Layout performance

### DIFF
--- a/src/complex/indic.rs
+++ b/src/complex/indic.rs
@@ -373,6 +373,7 @@ impl IndicWouldSubstituteFeature {
             let lookup = map.lookup(TableIndex::GSUB, index);
             let ctx = WouldApplyContext { glyphs, zero_context: self.zero_context };
             if face.gsub
+                .as_ref()
                 .and_then(|table| table.get_lookup(lookup.index))
                 .map_or(false, |lookup| lookup.would_apply(&ctx))
             {

--- a/src/face.rs
+++ b/src/face.rs
@@ -308,14 +308,14 @@ impl<'a> Face<'a> {
         }
     }
 
-    pub(crate) fn layout_table(&self, table_index: TableIndex) -> Option<SubstPosTable<'a>> {
+    pub(crate) fn layout_table(&self, table_index: TableIndex) -> Option<&SubstPosTable<'a>> {
         match table_index {
-            TableIndex::GSUB => self.gsub.map(|table| table.0),
-            TableIndex::GPOS => self.gpos.map(|table| table.0),
+            TableIndex::GSUB => self.gsub.as_ref().map(|table| &table.inner),
+            TableIndex::GPOS => self.gpos.as_ref().map(|table| &table.inner),
         }
     }
 
-    pub(crate) fn layout_tables(&self) -> impl Iterator<Item = (TableIndex, SubstPosTable<'a>)> + '_ {
+    pub(crate) fn layout_tables(&self) -> impl Iterator<Item = (TableIndex, &SubstPosTable<'a>)> + '_ {
         TableIndex::iter().filter_map(move |idx| self.layout_table(idx).map(|table| (idx, table)))
     }
 

--- a/src/glyph_set.rs
+++ b/src/glyph_set.rs
@@ -1,0 +1,142 @@
+use std::cmp::{self, Ordering};
+use std::ops::RangeInclusive;
+
+use ttf_parser::GlyphId;
+
+/// A set of glyphs.
+///
+/// Performs best when the glyphs are in consecutive ranges.
+#[derive(Clone, Debug)]
+pub struct GlyphSet {
+    ranges: Vec<RangeInclusive<GlyphId>>,
+}
+
+impl GlyphSet {
+    /// Create a new glyph set builder.
+    pub fn builder() -> GlyphSetBuilder {
+        GlyphSetBuilder { ranges: vec![] }
+    }
+
+    /// Check whether the glyph is contained in the set.
+    pub fn contains(&self, glyph: GlyphId) -> bool {
+        self.ranges.binary_search_by(|range| {
+            if glyph < *range.start() {
+                Ordering::Greater
+            } else if glyph <= *range.end() {
+                Ordering::Equal
+            } else {
+                Ordering::Less
+            }
+        }).is_ok()
+    }
+}
+
+/// A builder for a [`GlyphSet`].
+#[derive(Clone, Debug)]
+pub struct GlyphSetBuilder {
+    ranges: Vec<RangeInclusive<GlyphId>>,
+}
+
+impl GlyphSetBuilder {
+    /// Insert a single glyph.
+    pub fn insert(&mut self, glyph: GlyphId) {
+        self.ranges.push(glyph..=glyph);
+    }
+
+    /// Insert a range of glyphs.
+    pub fn insert_range(&mut self, range: RangeInclusive<GlyphId>) {
+        self.ranges.push(range);
+    }
+
+    /// Finish the set building.
+    pub fn finish(self) -> GlyphSet {
+        let mut ranges = self.ranges;
+
+        // Sort because we want to use binary search in `GlyphSet::contains`.
+        ranges.sort_by_key(|range| *range.start());
+
+        // The visited and merged ranges are in `ranges[..=left]` and the
+        // unvisited ranges in `ranges[right..]`.
+        let mut left = 0;
+        let mut right = 1;
+
+        // Merge touching and overlapping adjacent ranges.
+        //
+        // The cloning is cheap, it's just needed because `RangeInclusive<T>`
+        // does not implement `Copy`.
+        while let Some(next) = ranges.get(right).cloned() {
+            right += 1;
+
+            if let Some(prev) = ranges.get_mut(left) {
+                // Detect whether the ranges can be merged.
+                //
+                // We add one to `prev.end` because we want to merge touching ranges
+                // like `1..=3` and `4..=5`. We have to be careful with overflow,
+                // hence `saturating_add`.
+                if next.start().0 <= prev.end().0.saturating_add(1) {
+                    *prev = *prev.start()..=cmp::max(*prev.end(), *next.end());
+                    continue;
+                }
+            }
+
+            left += 1;
+            ranges[left] = next.clone();
+        }
+
+        // Can't overflow because `left < ranges.len() <= isize::MAX`.
+        ranges.truncate(left + 1);
+
+        GlyphSet { ranges }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_empty() {
+        assert!(GlyphSet::builder().finish().ranges.is_empty());
+    }
+
+    #[test]
+    fn test_contains() {
+        let mut builder = GlyphSet::builder();
+        builder.insert(GlyphId(1));
+        builder.insert_range(GlyphId(3)..=GlyphId(5));
+        let set = builder.finish();
+        assert!(set.contains(GlyphId(1)));
+        assert!(!set.contains(GlyphId(2)));
+        assert!(set.contains(GlyphId(3)));
+        assert!(set.contains(GlyphId(4)));
+        assert!(set.contains(GlyphId(5)));
+        assert!(!set.contains(GlyphId(6)));
+    }
+
+    #[test]
+    fn test_merge_ranges() {
+        let mut builder = GlyphSet::builder();
+        builder.insert(GlyphId(0));
+        builder.insert_range(GlyphId(2)..=GlyphId(6));
+        builder.insert_range(GlyphId(3)..=GlyphId(7));
+        builder.insert_range(GlyphId(9)..=GlyphId(10));
+        builder.insert(GlyphId(9));
+        builder.insert_range(GlyphId(18)..=GlyphId(21));
+        builder.insert_range(GlyphId(11)..=GlyphId(14));
+        assert_eq!(builder.finish().ranges, vec![
+            GlyphId(0)..=GlyphId(0),
+            GlyphId(2)..=GlyphId(7),
+            GlyphId(9)..=GlyphId(14),
+            GlyphId(18)..=GlyphId(21),
+        ])
+    }
+
+    #[test]
+    fn test_merge_ranges_at_numeric_boundaries() {
+        let mut builder = GlyphSet::builder();
+        builder.insert_range(GlyphId(3)..=GlyphId(u16::MAX));
+        builder.insert(GlyphId(u16::MAX - 1));
+        builder.insert(GlyphId(2));
+        assert_eq!(builder.finish().ranges, vec![GlyphId(2)..=GlyphId(u16::MAX)]);
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,6 +11,7 @@ mod aat;
 mod common;
 mod ffi;
 mod fallback;
+mod glyph_set;
 mod normalize;
 mod shape;
 mod plan;

--- a/src/ot/apply.rs
+++ b/src/ot/apply.rs
@@ -77,6 +77,7 @@ impl<'a, 'b> ApplyContext<'a, 'b> {
         let applied = match self.table_index {
             TableIndex::GSUB => {
                 self.face.gsub
+                    .as_ref()
                     .and_then(|table| table.get_lookup(sub_lookup_index))
                     .and_then(|lookup| {
                         self.lookup_props = lookup.props();
@@ -85,6 +86,7 @@ impl<'a, 'b> ApplyContext<'a, 'b> {
             }
             TableIndex::GPOS => {
                 self.face.gpos
+                    .as_ref()
                     .and_then(|table| table.get_lookup(sub_lookup_index))
                     .and_then(|lookup| {
                         self.lookup_props = lookup.props();

--- a/src/ot/layout.rs
+++ b/src/ot/layout.rs
@@ -2,6 +2,8 @@
 
 use std::ops::{Index, IndexMut};
 
+use ttf_parser::GlyphId;
+
 use crate::{Face, Tag};
 use crate::buffer::Buffer;
 use crate::common::TagExt;
@@ -60,6 +62,9 @@ pub trait LayoutLookup: Apply {
 
     /// Whether the lookup has to be applied backwards.
     fn is_reverse(&self) -> bool;
+
+    /// Whether any subtable of the lookup could apply at a specific glyph.
+    fn covers(&self, glyph: GlyphId) -> bool;
 }
 
 impl SubstPosTable<'_> {

--- a/src/ot/layout.rs
+++ b/src/ot/layout.rs
@@ -40,9 +40,6 @@ impl<T> IndexMut<TableIndex> for [T] {
 
 /// A lookup-based layout table (GSUB or GPOS).
 pub trait LayoutTable {
-    /// The tag of this table.
-    const TAG: Tag;
-
     /// The index of this table.
     const INDEX: TableIndex;
 
@@ -53,7 +50,7 @@ pub trait LayoutTable {
     type Lookup: LayoutLookup;
 
     /// Get the lookup at the specified index.
-    fn get_lookup(&self, index: LookupIndex) -> Option<Self::Lookup>;
+    fn get_lookup(&self, index: LookupIndex) -> Option<&Self::Lookup>;
 }
 
 /// A lookup in a layout table.
@@ -163,7 +160,7 @@ pub fn apply_layout_table<T: LayoutTable>(
     plan: &ShapePlan,
     face: &Face,
     buffer: &mut Buffer,
-    table: Option<T>,
+    table: Option<&T>,
 ) {
     let mut ctx = ApplyContext::new(T::INDEX, face, buffer);
 
@@ -193,7 +190,7 @@ pub fn apply_layout_table<T: LayoutTable>(
     }
 }
 
-fn apply_string<T: LayoutTable>(ctx: &mut ApplyContext, lookup: T::Lookup) {
+fn apply_string<T: LayoutTable>(ctx: &mut ApplyContext, lookup: &T::Lookup) {
     if ctx.buffer.is_empty() || ctx.lookup_mask == 0 {
         return;
     }
@@ -225,7 +222,7 @@ fn apply_string<T: LayoutTable>(ctx: &mut ApplyContext, lookup: T::Lookup) {
     }
 }
 
-fn apply_forward(ctx: &mut ApplyContext, lookup: impl Apply) -> bool {
+fn apply_forward(ctx: &mut ApplyContext, lookup: &impl Apply) -> bool {
     let mut ret = false;
     while ctx.buffer.idx < ctx.buffer.len && ctx.buffer.successful {
         let cur = ctx.buffer.cur(0);
@@ -241,7 +238,7 @@ fn apply_forward(ctx: &mut ApplyContext, lookup: impl Apply) -> bool {
     ret
 }
 
-fn apply_backward(ctx: &mut ApplyContext, lookup: impl Apply) -> bool {
+fn apply_backward(ctx: &mut ApplyContext, lookup: &impl Apply) -> bool {
     let mut ret = false;
     loop {
         let cur = ctx.buffer.cur(0);

--- a/src/ot/position.rs
+++ b/src/ot/position.rs
@@ -1,3 +1,6 @@
+use std::convert::TryFrom;
+
+use ttf_parser::GlyphId;
 use ttf_parser::parser::{Offset, Offset16};
 
 use crate::{Direction, Face};
@@ -107,15 +110,22 @@ impl LayoutLookup for PosLookup<'_> {
     fn is_reverse(&self) -> bool {
         false
     }
+
+    fn covers(&self, glyph: GlyphId) -> bool {
+        self.coverage.contains(glyph)
+    }
 }
 
 impl Apply for PosLookup<'_> {
     fn apply(&self, ctx: &mut ApplyContext) -> Option<()> {
-        for subtable in &self.subtables {
-            if subtable.apply(ctx).is_some() {
-                return Some(());
+        if self.covers(GlyphId(u16::try_from(ctx.buffer.cur(0).codepoint).unwrap())) {
+            for subtable in &self.subtables {
+                if subtable.apply(ctx).is_some() {
+                    return Some(());
+                }
             }
         }
+
         None
     }
 }

--- a/src/tables/gpos.rs
+++ b/src/tables/gpos.rs
@@ -4,17 +4,42 @@ use super::gsubgpos::*;
 use super::*;
 use crate::Face;
 
-#[derive(Clone, Copy, Debug)]
-pub struct PosTable<'a>(pub SubstPosTable<'a>);
+#[derive(Clone, Debug)]
+pub struct PosTable<'a> {
+    pub inner: SubstPosTable<'a>,
+    pub lookups: Vec<Option<PosLookup<'a>>>,
+}
 
 impl<'a> PosTable<'a> {
     pub fn parse(data: &'a [u8]) -> Option<Self> {
-        SubstPosTable::parse(data).map(Self)
+        let inner = SubstPosTable::parse(data)?;
+        let lookups = (0..inner.lookup_count())
+            .map(|i| inner.get_lookup(LookupIndex(i)).map(PosLookup::parse))
+            .collect();
+
+        Some(Self { inner, lookups})
     }
 }
 
-#[derive(Clone, Copy, Debug)]
-pub struct PosLookup<'a>(pub Lookup<'a>);
+#[derive(Clone, Debug)]
+pub struct PosLookup<'a> {
+    pub subtables: Vec<PosLookupSubtable<'a>>,
+    pub props: u32,
+}
+
+impl<'a> PosLookup<'a> {
+    pub fn parse(lookup: Lookup<'a>) -> Self {
+        let subtables = lookup
+            .subtables
+            .into_iter()
+            .flat_map(|data| PosLookupSubtable::parse(data, lookup.kind))
+            .collect();
+
+        let props = lookup.props();
+
+        Self { subtables, props }
+    }
+}
 
 #[derive(Clone, Copy, Debug)]
 pub enum PosLookupSubtable<'a> {

--- a/src/tables/gsub.rs
+++ b/src/tables/gsub.rs
@@ -3,19 +3,46 @@
 use super::gsubgpos::*;
 use super::*;
 
-#[derive(Clone, Copy, Debug)]
-pub struct SubstTable<'a>(pub SubstPosTable<'a>);
+#[derive(Clone, Debug)]
+pub struct SubstTable<'a> {
+    pub inner: SubstPosTable<'a>,
+    pub lookups: Vec<Option<SubstLookup<'a>>>,
+}
 
 impl<'a> SubstTable<'a> {
     pub fn parse(data: &'a [u8]) -> Option<Self> {
-        SubstPosTable::parse(data).map(Self)
+        let inner = SubstPosTable::parse(data)?;
+        let lookups = (0..inner.lookup_count())
+            .map(|i| inner.get_lookup(LookupIndex(i)).map(SubstLookup::parse))
+            .collect();
+
+        Some(Self { inner, lookups})
     }
 }
 
-#[derive(Clone, Copy, Debug)]
-pub struct SubstLookup<'a>(pub Lookup<'a>);
+#[derive(Clone, Debug)]
+pub struct SubstLookup<'a> {
+    pub subtables: Vec<SubstLookupSubtable<'a>>,
+    pub props: u32,
+    pub reverse: bool,
+}
 
-#[derive(Clone, Copy, Debug)]
+impl<'a> SubstLookup<'a> {
+    pub fn parse(lookup: Lookup<'a>) -> Self {
+        let subtables: Vec<_> = lookup
+            .subtables
+            .into_iter()
+            .flat_map(|data| SubstLookupSubtable::parse(data, lookup.kind))
+            .collect();
+
+        let props = lookup.props();
+        let reverse = subtables.iter().all(|subtable| subtable.is_reverse());
+
+        Self { subtables, props, reverse }
+    }
+}
+
+#[derive(Clone, Debug)]
 pub enum SubstLookupSubtable<'a> {
     Single(SingleSubst<'a>),
     Multiple(MultipleSubst<'a>),

--- a/src/tables/gsubgpos.rs
+++ b/src/tables/gsubgpos.rs
@@ -5,8 +5,9 @@ use std::cmp::Ordering;
 
 use ttf_parser::NormalizedCoordinate;
 
-use super::*;
 use crate::{Face, Tag};
+use crate::glyph_set::GlyphSetBuilder;
+use super::*;
 
 /// A GSUB or GPOS table.
 #[derive(Clone, Copy, Debug)]
@@ -578,6 +579,22 @@ impl<'a> Coverage<'a> {
                 let record = RangeRecord::binary_search(records, glyph)?;
                 let offset = glyph.0 - record.start.0;
                 record.value.checked_add(offset)
+            }
+        }
+    }
+
+    /// Collect this coverage table into a glyph set.
+    pub fn collect(&self, set: &mut GlyphSetBuilder) {
+        match *self {
+            Self::Format1 { glyphs } => {
+                for glyph in glyphs {
+                    set.insert(glyph);
+                }
+            }
+            Self::Format2 { records } => {
+                for record in records {
+                    set.insert_range(record.start..=record.end);
+                }
             }
         }
     }


### PR DESCRIPTION
I finally got around to work on the bad OpenType performance and I was able to improve performance quite a lot with relatively little changes! 

The first change was to keep all GSUB/GPOS lookups and their subtables in vectors instead of re-parsing them all the time. This improved performance across the board, especially the arabic shaping benchmark by a factor of 4.5x. 

The second change was to collect the coverage of all subtables in a lookup into a glyph set upfront. This set is checked before any complex apply/would_apply machinery runs. I did not port harfbuzz's bit-based set. Instead, I first experimented with a simple sorted vector of glyphs and Rust's hash set, but performance was not so great, so in the end I wrote a simple set based on a sorted `Vec` of ranges and binary search. The effect of this change is a bit less clear cut. It gives a good boost for the arabic shaping benchmark (around 1.6x faster), but makes latin shaping slower. But Latin shaping is, interestingly, still a lot faster than through `harfbuzz-rs`. I wonder what's the reason for that.

### Benchmarks
**Harfbuzz (through harfbuzz-rs)**
```
test shape_arabic_hb ... bench:     786,963 ns/iter (+/- 66,127)
test shape_latin_hb  ... bench:     136,060 ns/iter (+/- 9,707)
test shape_zalgo_hb  ... bench:     196,338 ns/iter (+/- 16,224)
```

**Rustybuzz before any of my PRs** (`5244b48`)
```
test shape_arabic_rb ... bench:     793,146 ns/iter (+/- 33,016)
test shape_latin_rb  ... bench:      76,425 ns/iter (+/- 4,093)
test shape_zalgo_rb  ... bench:     218,218 ns/iter (+/- 29,286)
```

**Rustybuzz master** (`043a0b5`)
```
test shape_arabic_rb ... bench:   6,302,550 ns/iter (+/- 104,301)
test shape_latin_rb  ... bench:      58,398 ns/iter (+/- 1,932)
test shape_zalgo_rb  ... bench:     517,315 ns/iter (+/- 14,301)
```

**Improvement: Parsing lookups and subtables only once and storing them in vectors** (`6332c81`)
```
test shape_arabic_rb ... bench:   1,426,730 ns/iter (+/- 13,970)
test shape_latin_rb  ... bench:      37,537 ns/iter (+/- 1,091)
test shape_zalgo_rb  ... bench:     270,590 ns/iter (+/- 24,512)
```

**Improvements: Parsing only once + collecting combined coverage of a lookup's subtables into a glyph set** (`f3f1a16`)
```
test shape_arabic_rb ... bench:     875,941 ns/iter (+/- 11,062)
test shape_latin_rb  ... bench:      66,402 ns/iter (+/- 1,957)
test shape_zalgo_rb  ... bench:     274,015 ns/iter (+/- 5,692)
```