### PR TITLE
Creating Face from ttf_parser::Face

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,12 +14,12 @@ exclude = ["benches/**"]
 
 [dependencies]
 bitflags = "1.2"
-bytemuck = { version = "1.4", features = ["extern_crate_alloc"] }
-smallvec = "1.4"
-ttf-parser = "0.9"
+bytemuck = { version = "1.5", features = ["extern_crate_alloc"] }
+smallvec = "1.6"
+ttf-parser = "0.12"
 unicode-bidi-mirroring = "0.1"
 unicode-ccc = "0.1"
-unicode-general-category = "0.2"
+unicode-general-category = "0.4"
 unicode-script = "0.5"
 
 [dev-dependencies]

--- a/src/face.rs
+++ b/src/face.rs
@@ -57,18 +57,18 @@ impl<'a> AsMut<ttf_parser::Face<'a>> for Face<'a> {
 }
 
 impl<'a> core::ops::Deref for Face<'a> {
-    type Target = ttf_parser::FaceTables<'a>;
+    type Target = ttf_parser::Face<'a>;
 
     #[inline]
     fn deref(&self) -> &Self::Target {
-        core::ops::Deref::deref(&self.ttfp_face)
+        &self.ttfp_face
     }
 }
 
 impl<'a> core::ops::DerefMut for Face<'a> {
     #[inline]
     fn deref_mut(&mut self) -> &mut Self::Target {
-        core::ops::DerefMut::deref_mut(&mut self.ttfp_face)
+        &mut self.ttfp_face
     }
 }
 

--- a/src/unicode.rs
+++ b/src/unicode.rs
@@ -830,7 +830,7 @@ mod tests {
     fn check_unicode_version() {
         assert_eq!(unicode_bidi_mirroring::UNICODE_VERSION,     (13, 0, 0));
         assert_eq!(unicode_ccc::UNICODE_VERSION,                (13, 0, 0));
-        assert_eq!(unicode_general_category::UNICODE_VERSION,   (12, 1, 0)); // TODO: update
+        assert_eq!(unicode_general_category::UNICODE_VERSION,   (13, 0, 0));
         assert_eq!(unicode_script::UNICODE_VERSION,             (13, 0, 0));
         assert_eq!(crate::unicode_norm::UNICODE_VERSION,        (13, 0, 0));
     }


### PR DESCRIPTION
Mostly solves #23. via implementing `Font::from_face` and `AsRef`/`AsMut` to `ttf_parser::Face` and `Deref`/`DerefMut` to `ttf_parser::FaceTables`.

All this allows use of `Face` as a drop-in replacement for `ttf_parser::Face`.

In addition, I updated the dependencies and made `Face::units_per_em` public.