### PR TITLE
Fix `no_std` support by using `libm` for rounding

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,11 +16,21 @@ exclude = ["benches/**"]
 bitflags = "1.2"
 bytemuck = { version = "1.5", features = ["extern_crate_alloc"] }
 smallvec = "1.6"
-ttf-parser = "0.15"
+ttf-parser = { version = "0.15", default-features = false, features = [
+    "opentype-layout",
+    "apple-layout",
+    "variable-fonts",
+    "glyph-names",
+] }
 unicode-bidi-mirroring = "0.1"
 unicode-ccc = "0.1.2"
 unicode-general-category = "0.4"
 unicode-script = "0.5.2"
+libm = { version = "0.2.2", optional = true }
+
+[features]
+default = ["std"]
+std = []
 
 [dev-dependencies]
 pico-args = "0.3"

--- a/src/aat/tracking.rs
+++ b/src/aat/tracking.rs
@@ -78,7 +78,7 @@ impl TrackTableDataExt for ttf_parser::trak::TrackData<'_> {
             idx -= 1;
         }
 
-        self.interpolate_at(idx as u16, ptem, &track).map(|n| n.round() as i32)
+        self.interpolate_at(idx as u16, ptem, &track).map(|n| crate::round(n) as i32)
     }
 
     fn interpolate_at(

--- a/src/face.rs
+++ b/src/face.rs
@@ -237,10 +237,10 @@ impl<'a> Face<'a> {
             if img.format == ttf_parser::RasterImageFormat::PNG {
                 let scale = self.units_per_em as f32 / img.pixels_per_em as f32;
                 return Some(GlyphExtents {
-                    x_bearing: (f32::from(img.x) * scale).round() as i32,
-                    y_bearing: ((f32::from(img.y) + f32::from(img.height)) * scale).round() as i32,
-                    width: (f32::from(img.width) * scale).round() as i32,
-                    height: (-f32::from(img.height) * scale).round() as i32,
+                    x_bearing: crate::round(f32::from(img.x) * scale) as i32,
+                    y_bearing: crate::round((f32::from(img.y) + f32::from(img.height)) * scale) as i32,
+                    width: crate::round(f32::from(img.width) * scale) as i32,
+                    height: crate::round(-f32::from(img.height) * scale) as i32,
                 });
             }
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,6 +5,12 @@ A complete [harfbuzz](https://github.com/harfbuzz/harfbuzz) shaping algorithm po
 #![no_std]
 #![warn(missing_docs)]
 
+#[cfg(not(any(feature = "std", feature = "libm")))]
+compile_error!("You have to activate either the `std` or the `libm` feature.");
+
+#[cfg(feature = "std")]
+extern crate std;
+
 extern crate alloc;
 
 #[macro_use]
@@ -36,3 +42,14 @@ pub use crate::face::Face;
 pub use crate::shape::shape;
 
 type Mask = u32;
+
+fn round(x: f32) -> f32 {
+    #[cfg(feature = "std")]
+    {
+        x.round()
+    }
+    #[cfg(not(feature = "std"))]
+    {
+        libm::roundf(x)
+    }
+}

--- a/src/ot/position.rs
+++ b/src/ot/position.rs
@@ -617,7 +617,7 @@ impl DeviceExt for Device<'_> {
             Device::Variation(variation) => {
                 face.tables().gdef?
                     .glyph_variation_delta(variation.outer_index, variation.inner_index, face.variation_coordinates())
-                    .and_then(|float| i32::try_num_from(float.round()))
+                    .and_then(|float| i32::try_num_from(crate::round(float)))
             }
         }
     }
@@ -628,7 +628,7 @@ impl DeviceExt for Device<'_> {
             Device::Variation(variation) => {
                 face.tables().gdef?
                     .glyph_variation_delta(variation.outer_index, variation.inner_index, face.variation_coordinates())
-                    .and_then(|float| i32::try_num_from(float.round()))
+                    .and_then(|float| i32::try_num_from(crate::round(float)))
             }
         }
     }


### PR DESCRIPTION
Turns out that `no_std` wasn't properly supported as `f32::round` isn't available on targets that don't have std. As with other crates, there's now two mutually exclusive features `std` and `libm` that you have to choose.

Additionally this applies a bunch of clippy fixes.