### PR TITLE
Don't publish test data to crates.io

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ repository = "https://github.com/RazrFalcon/rustybuzz"
 license = "MIT"
 keywords = ["text", "shaping", "opentype", "truetype"]
 categories = ["text-processing"]
-exclude = ["benches/**"]
+exclude = ["benches/", "tests"/]
 
 [dependencies]
 bitflags = "1.2"


### PR DESCRIPTION
Brings down the crate size from 1.2MB to 230KB.

Right now anyone running `cargo install something-depending-on-rustybuzz` will have to also download rustybuzz's test data, which is useless to them and just wastes bandwidth.

If anyone intends to develop rustybuzz, they'll clone the git repo instead of fetching the crate from crates.io (which doesn't even have a UI for doing that).