### PR TITLE
Bump `ttf-parser` to `0.19`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ unicode-script = "0.5.2"
 libm = { version = "0.2.2", optional = true }
 
 [dependencies.ttf-parser]
-version = "0.18"
+version = "0.19"
 default-features = false
 features = [
     "opentype-layout",


### PR DESCRIPTION
`cosmic_text` already uses `fontdb 0.14` which is on `ttf-parser 0.19` (and so is `egui` via `epaint 0.22` -> `ab_glyph 0.2.21` -> `owned_ttf_parser 0.19` -> `ttf-parser 0.19`), causing a duplicate dependency on `ttf-parser 0.18.1` via `rustybuzz`, which is also a direct dependency of `cosmic_text`.
