### PR TITLE
Replace `unicode-general-category` w/ `unicode-properties`.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ bytemuck = { version = "1.5", features = ["extern_crate_alloc"] }
 smallvec = "1.6"
 unicode-bidi-mirroring = "0.1"
 unicode-ccc = "0.1.2"
-unicode-general-category = "0.6"
+unicode-properties = { version = "0.1.0", default-features = false, features = ["general-category"] }
 unicode-script = "0.5.2"
 libm = { version = "0.2.2", optional = true }
 

--- a/src/unicode.rs
+++ b/src/unicode.rs
@@ -1,6 +1,6 @@
 use core::convert::TryFrom;
 
-pub use unicode_general_category::GeneralCategory;
+pub use unicode_properties::GeneralCategory;
 pub use unicode_ccc::CanonicalCombiningClass; // TODO: prefer unic-ucd-normal::CanonicalCombiningClass
 
 use crate::Script;
@@ -482,7 +482,7 @@ impl CharExt for char {
     }
 
     fn general_category(self) -> GeneralCategory {
-        unicode_general_category::get_general_category(self)
+        unicode_properties::general_category::UnicodeGeneralCategory::general_category(self)
     }
 
     fn combining_class(self) -> CanonicalCombiningClass {
@@ -830,7 +830,7 @@ mod tests {
     fn check_unicode_version() {
         assert_eq!(unicode_bidi_mirroring::UNICODE_VERSION,     (13, 0, 0));
         assert_eq!(unicode_ccc::UNICODE_VERSION,                (13, 0, 0));
-        assert_eq!(unicode_general_category::UNICODE_VERSION,   (15, 0, 0));
+        assert_eq!(unicode_properties::UNICODE_VERSION,         (15, 0, 0));
         assert_eq!(unicode_script::UNICODE_VERSION,             (15, 0, 0));
         assert_eq!(crate::unicode_norm::UNICODE_VERSION,        (13, 0, 0));
     }


### PR DESCRIPTION
What prompted me to look at `unicode-general-category` was these build timings:

<img src="https://github.com/RazrFalcon/rustybuzz/assets/77424/f7f219c3-b793-4c80-897c-82909a79a681" height="250">

While `ttf-parser` prevents `rustybuzz` from starting its compilation earlier anyway, it still seemed weird that only one of several `unicode-*` deps was so much more involved than the others.
(And within a large build, it is possible that such a serial dependency would have an impact)

The description of `unicode-general-category` seemed to suggest it was used for performance reasons, and I spent some time optimizing away some low-hanging fruit (it wastes over half a second just on not using buffered IO, but also it generates Rust source code instead of binary blobs, and there's a few more things like that).

---

But then I noticed something: [the `yeslogic` org has a bunch of `unicode-*` crates](https://github.com/yeslogic?q=unicode-&type=all&language=&sort=#org-repositories), but [most of them are prefixed with `yeslogic-` on `crates.io`](https://github.com/yeslogic/unicode-script/blob/fcec08dbae0f04300eb4f44e4981f740dcd4b1fa/Cargo.toml#L2) (since they're alternatives to e.g. `unicode-rs` crates).

And there's no any other obvious choice of a crate for querying "general category", not on `crates.io`. Which leads me to believe the use of an `yeslogic` crate wasn't intentional but rather accidental/incidental (as it looked like the only option, and it didn't have a prefix that would make it seem out of place).

---

There are two blockers for this PR:
* ~~the replacement I use ([`unicode-rs`' `unicode-properties` crate](https://github.com/unicode-rs/unicode-properties)) is not published on `crates.io` yet, for some reason (cc @crlf0710 @manishearth)~~
* ~~I had to replace all the variant uses, because of the different naming convention at play~~
  * ~~if `yeslogic` is not responsible for its convention (and instead it comes from e.g. `ucd-generate`), it may be worth having `unicode-properties` use that one too, requiring no changes to `rustybuzz` at use sites~~
  * **EDIT**: solved by https://github.com/unicode-rs/unicode-properties/issues/1