### PR TITLE
Add features to `Cargo.toml` matching those of `ttf-parser`.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,16 +25,14 @@ libm = { version = "0.2.2", optional = true }
 [dependencies.ttf-parser]
 version = "0.19"
 default-features = false
-features = [
-    "opentype-layout",
-    "apple-layout",
-    "variable-fonts",
-    "glyph-names",
-]
+features = ["opentype-layout"]
 
 [features]
-default = ["std"]
+default = ["std", "apple-layout", "variable-fonts", "glyph-names"]
 std = []
+apple-layout = ["ttf-parser/apple-layout"]
+variable-fonts = ["ttf-parser/variable-fonts"]
+glyph-names = ["ttf-parser/glyph-names"]
 
 [dev-dependencies]
 pico-args = { version = "0.5", features = ["eq-separator"] }

--- a/examples/shape.rs
+++ b/examples/shape.rs
@@ -134,6 +134,7 @@ fn main() {
 
     face.set_points_per_em(args.font_ptem);
 
+    #[cfg(feature = "variable-fonts")]
     if !args.variations.is_empty() {
         face.set_variations(&args.variations);
     }

--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -1719,7 +1719,14 @@ impl GlyphBuffer {
         let mut y = 0;
         for (info, pos) in info.iter().zip(pos) {
             if !flags.contains(SerializeFlags::NO_GLYPH_NAMES) {
-                match face.glyph_name(info.as_glyph()) {
+                let glyph_name = {
+                    #[cfg(feature = "glyph-names")]
+                    { face.glyph_name(info.as_glyph()) }
+
+                    #[cfg(not(feature = "glyph-names"))]
+                    { None }
+                };
+                match glyph_name {
                     Some(name) => s.push_str(name),
                     None => write!(&mut s, "gid{}", info.glyph_id)?,
                 }

--- a/src/face.rs
+++ b/src/face.rs
@@ -121,6 +121,7 @@ impl<'a> Face<'a> {
     }
 
     /// Sets font variations.
+    #[cfg(feature = "variable-fonts")]
     pub fn set_variations(&mut self, variations: &[Variation]) {
         for variation in variations {
             self.set_variation(variation.tag, variation.value);
@@ -167,6 +168,7 @@ impl<'a> Face<'a> {
 
     fn glyph_advance(&self, glyph: GlyphId, is_vertical: bool) -> u32 {
         let face = &self.ttfp_face;
+        #[cfg(feature = "variable-fonts")]
         if face.is_variable() &&
            face.has_non_default_variation_coordinates() &&
            face.tables().hvar.is_none() &&
@@ -207,6 +209,7 @@ impl<'a> Face<'a> {
 
     pub(crate) fn glyph_side_bearing(&self, glyph: GlyphId, is_vertical: bool) -> i32 {
         let face = &self.ttfp_face;
+        #[cfg(feature = "variable-fonts")]
         if  face.is_variable() &&
             face.tables().hvar.is_none() &&
             face.tables().vvar.is_none()
@@ -252,6 +255,7 @@ impl<'a> Face<'a> {
         })
     }
 
+    #[cfg(feature = "glyph-names")]
     pub(crate) fn glyph_name(&self, glyph: GlyphId) -> Option<&str> {
         self.ttfp_face.glyph_name(glyph)
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,6 +15,7 @@ extern crate alloc;
 
 #[macro_use]
 mod buffer;
+#[cfg(feature = "apple-layout")]
 mod aat;
 mod common;
 mod fallback;

--- a/tests/shaping_impl.rs
+++ b/tests/shaping_impl.rs
@@ -65,6 +65,7 @@ pub fn shape(font_path: &str, text: &str, options: &str) -> String {
 
     face.set_points_per_em(args.font_ptem);
 
+    #[cfg(feature = "variable-fonts")]
     if !args.variations.is_empty() {
         let variations: Vec<_> = args.variations.iter()
             .map(|s| rustybuzz::Variation::from_str(s).unwrap()).collect();


### PR DESCRIPTION
I mostly wanted to be able to see the impact on compile times of making functionality optional.
(I left `opentype-layout` mandatory as I assume that's the common baseline that most/all fonts will need)

The implementation isn't great, the way I used `#[cfg]`s gets a bit messy, but I mostly focused on getting it to compile w/ all possible combinations of features (there's still some warnings left tho).

I still need to try get some reliable build timings to compare the impact but I'm not so sure it's worth it, the bulk of the cost may still be tied to `opentype-layout` which isn't really negotiable.

At the very least, the `glyph-names` feature could probably be added simply for the reason stated in `ttf-parser` (IIRC, it's optional specifically because it has a non-trivial size cost).