### PR TITLE
Allow setting pre- and post-contexts in `UnicodeBuffer`

### DIFF
--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -1,5 +1,6 @@
 use alloc::{string::String, vec::Vec};
 use core::convert::TryFrom;
+use core::mem;
 
 use ttf_parser::GlyphId;
 
@@ -1381,7 +1382,7 @@ impl Buffer {
             return;
         }
 
-        self.ensure(self.len + item_length / 4);
+        self.ensure(self.len + item_length * mem::size_of::<u8>() / 4);
 
         // If buffer is empty and pre-context provided, install it.
         // This check is written this way, to make sure people can

--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -1,6 +1,5 @@
 use alloc::{string::String, vec::Vec};
 use core::convert::TryFrom;
-use core::mem;
 
 use ttf_parser::GlyphId;
 
@@ -1382,7 +1381,7 @@ impl Buffer {
             return;
         }
 
-        self.ensure(self.len + item_length * mem::size_of::<u8>() / 4);
+        self.ensure(self.len + item_length / 4);
 
         // If buffer is empty and pre-context provided, install it.
         // This check is written this way, to make sure people can

--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -1298,6 +1298,10 @@ impl Buffer {
         self.idx += count;
     }
 
+    fn clear_context(&mut self, side: usize) {
+        self.context_len[side] = 0;
+    }
+
     pub fn sort(&mut self, start: usize, end: usize, cmp: impl Fn(&GlyphInfo, &GlyphInfo) -> bool) {
         assert!(!self.have_positions);
 
@@ -1377,6 +1381,20 @@ impl Buffer {
 
         for (i, c) in text.char_indices() {
             self.add(c as u32, i as u32);
+        }
+    }
+
+    fn set_pre_context(&mut self, text: &str) {
+        self.clear_context(0);
+        for (i, c) in text.chars().rev().enumerate().take(CONTEXT_LENGTH) {
+            self.context[0][i] = c;
+        }
+    }
+
+    fn set_post_context(&mut self, text: &str) {
+        self.clear_context(1);
+        for (i, c) in text.chars().enumerate().take(CONTEXT_LENGTH) {
+            self.context[1][i] = c;
         }
     }
 
@@ -1581,6 +1599,18 @@ impl UnicodeBuffer {
     #[inline]
     pub fn push_str(&mut self, str: &str) {
         self.0.push_str(str);
+    }
+
+    /// Sets the pre-context for this buffer.
+    #[inline]
+    pub fn set_pre_context(&mut self, str: &str) {
+        self.0.set_pre_context(str)
+    }
+
+    /// Sets the post-context for this buffer.
+    #[inline]
+    pub fn set_post_context(&mut self, str: &str) {
+        self.0.set_post_context(str)
     }
 
     /// Appends a character to a buffer with the given cluster value.

--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -1,6 +1,5 @@
 use alloc::{string::String, vec::Vec};
 use core::convert::TryFrom;
-use core::mem;
 
 use ttf_parser::GlyphId;
 
@@ -1299,10 +1298,6 @@ impl Buffer {
         self.idx += count;
     }
 
-    fn clear_context(&mut self, side: usize) {
-        self.context_len[side] = 0;
-    }
-
     pub fn sort(&mut self, start: usize, end: usize, cmp: impl Fn(&GlyphInfo, &GlyphInfo) -> bool) {
         assert!(!self.have_positions);
 
@@ -1377,44 +1372,11 @@ impl Buffer {
         self.len == 0
     }
 
-    fn add_utf8(&mut self, text: &str, item_offset: usize, item_length: usize) {
-        if item_length > (i32::MAX / 8) as usize {
-            return;
-        }
+    fn push_str(&mut self, text: &str) {
+        self.ensure(self.len + text.chars().count());
 
-        self.ensure(self.len + item_length * mem::size_of::<u8>() / 4);
-
-        // If buffer is empty and pre-context provided, install it.
-        // This check is written this way, to make sure people can
-        // provide pre-context in one add_utf() call, then provide
-        // text in a follow-up call.  See:
-        //
-        // https://bugzilla.mozilla.org/show_bug.cgi?id=801410#c13
-        if self.len == 0 && item_offset > 0 {
-            // Add pre-context
-            self.clear_context(0);
-            for (i, c) in text[..item_offset]
-                .chars()
-                .rev()
-                .enumerate()
-                .take(CONTEXT_LENGTH)
-            {
-                self.context[0][i] = c;
-            }
-        }
-
-        for (i, c) in text[item_offset..item_offset + item_length].char_indices() {
-            self.add(c as u32, (i + item_offset) as u32);
-        }
-
-        // Add post-context
-        self.clear_context(1);
-        for (i, c) in text[item_offset + item_length..]
-            .chars()
-            .enumerate()
-            .take(CONTEXT_LENGTH)
-        {
-            self.context[1][i] = c;
+        for (i, c) in text.char_indices() {
+            self.add(c as u32, i as u32);
         }
     }
 
@@ -1618,14 +1580,7 @@ impl UnicodeBuffer {
     /// Pushes a string to a buffer.
     #[inline]
     pub fn push_str(&mut self, str: &str) {
-        self.0.add_utf8(str, 0, str.len());
-    }
-
-    /// Pushes a substring of a larger string to a buffer.
-    /// The rest of the string acts as context for shaping.
-    #[inline]
-    pub fn add_utf8(&mut self, str: &str, item_offset: usize, item_length: usize) {
-        self.0.add_utf8(str, item_offset, item_length);
+        self.0.push_str(str);
     }
 
     /// Appends a character to a buffer with the given cluster value.


### PR DESCRIPTION
Resolves #60.

Only dealing with the UTF-8 version for now. I personally need a UTF-16 version as well, but generalizing this for other encodings can come later.