### PR TITLE
Add support for reusable ShapePlans.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -41,7 +41,8 @@ pub use crate::buffer::{
 };
 pub use crate::common::{script, Direction, Feature, Language, Script, Variation};
 pub use crate::face::Face;
-pub use crate::shape::shape;
+pub use crate::plan::ShapePlan;
+pub use crate::shape::{shape, shape_with_plan};
 
 type Mask = u32;
 

--- a/src/plan.rs
+++ b/src/plan.rs
@@ -55,7 +55,7 @@ impl ShapePlan {
         assert_ne!(direction, Direction::Invalid);
         let mut planner = ShapePlanner::new(face, direction, script, language);
         planner.collect_features(user_features);
-        planner.compile()
+        planner.compile(user_features)
     }
 
     pub(crate) fn data<T: 'static>(&self) -> &T {
@@ -73,7 +73,6 @@ pub struct ShapePlanner<'a> {
     pub script_zero_marks: bool,
     pub script_fallback_mark_positioning: bool,
     pub shaper: &'static ComplexShaper,
-    pub user_features: Vec<Feature>,
 }
 
 impl<'a> ShapePlanner<'a> {
@@ -115,7 +114,6 @@ impl<'a> ShapePlanner<'a> {
             script_zero_marks,
             script_fallback_mark_positioning,
             shaper,
-            user_features: Default::default(),
         }
     }
 
@@ -228,7 +226,6 @@ impl<'a> ShapePlanner<'a> {
             };
             self.ot_map.add_feature(feature.tag, flags, feature.value);
         }
-        self.user_features = user_features.to_vec();
 
         if self.apply_morx {
             for feature in user_features {
@@ -242,7 +239,7 @@ impl<'a> ShapePlanner<'a> {
         }
     }
 
-    fn compile(mut self) -> ShapePlan {
+    fn compile(mut self, user_features: &[Feature]) -> ShapePlan {
         let ot_map = self.ot_map.compile();
 
         let aat_map = if self.apply_morx {
@@ -358,7 +355,7 @@ impl<'a> ShapePlanner<'a> {
             apply_kerx,
             apply_morx,
             apply_trak,
-            user_features: self.user_features,
+            user_features: user_features.to_vec(),
         };
 
         if let Some(func) = self.shaper.create_data {

--- a/src/shape.rs
+++ b/src/shape.rs
@@ -39,9 +39,7 @@ pub fn shape(face: &Face, features: &[Feature], mut buffer: UnicodeBuffer) -> Gl
 ///
 /// Will panic when debugging assertions are enabled if the buffer and plan have mismatched
 /// properties.
-pub fn shape_with_plan(face: &Face, plan: &ShapePlan, mut buffer: UnicodeBuffer) -> GlyphBuffer {
-    buffer.guess_segment_properties();
-
+pub fn shape_with_plan(face: &Face, plan: &ShapePlan, buffer: UnicodeBuffer) -> GlyphBuffer {
     let mut buffer = buffer.0;
     buffer.guess_segment_properties();
 

--- a/src/shape.rs
+++ b/src/shape.rs
@@ -13,8 +13,12 @@ use crate::{
 
 /// Shapes the buffer content using provided font and features.
 ///
-/// Consumes the buffer. You can then run `GlyphBuffer::clear` to get the `UnicodeBuffer` back
+/// Consumes the buffer. You can then run [`GlyphBuffer::clear`] to get the [`UnicodeBuffer`] back
 /// without allocating a new one.
+///
+/// If you plan to shape multiple strings using the same [`Face`] prefer [`shape_with_plan`].
+/// This is because [`ShapePlan`] initialization is pretty slow and should preferably be called
+/// once for each [`Face`].
 pub fn shape(face: &Face, features: &[Feature], mut buffer: UnicodeBuffer) -> GlyphBuffer {
     buffer.0.guess_segment_properties();
     let plan = ShapePlan::new(
@@ -29,7 +33,7 @@ pub fn shape(face: &Face, features: &[Feature], mut buffer: UnicodeBuffer) -> Gl
 
 /// Shapes the buffer content using the provided font and plan.
 ///
-/// Consumes the buffer. You can then run `GlyphBuffer::clear` to get the `UnicodeBuffer` back
+/// Consumes the buffer. You can then run [`GlyphBuffer::clear`] to get the [`UnicodeBuffer`] back
 /// without allocating a new one.
 ///
 /// It is up to the caller to ensure that the shape plan matches the properties of the provided

--- a/src/shape.rs
+++ b/src/shape.rs
@@ -7,32 +7,57 @@ use crate::buffer::{
 use crate::complex::ZeroWidthMarksMode;
 use crate::plan::ShapePlan;
 use crate::unicode::{CharExt, GeneralCategory, GeneralCategoryExt};
-use crate::{aat, fallback, normalize, ot, Direction, Face, Feature, GlyphBuffer, UnicodeBuffer};
+use crate::{
+    aat, fallback, normalize, ot, script, Direction, Face, Feature, GlyphBuffer, UnicodeBuffer,
+};
 
 /// Shapes the buffer content using provided font and features.
 ///
 /// Consumes the buffer. You can then run `GlyphBuffer::clear` to get the `UnicodeBuffer` back
 /// without allocating a new one.
-pub fn shape(face: &Face, features: &[Feature], buffer: UnicodeBuffer) -> GlyphBuffer {
+pub fn shape(face: &Face, features: &[Feature], mut buffer: UnicodeBuffer) -> GlyphBuffer {
+    buffer.0.guess_segment_properties();
+    let plan = ShapePlan::new(
+        face,
+        buffer.0.direction,
+        buffer.0.script,
+        buffer.0.language.as_ref(),
+        features,
+    );
+    shape_with_plan(face, &plan, buffer)
+}
+
+/// Shapes the buffer content using the provided font and plan.
+///
+/// Consumes the buffer. You can then run `GlyphBuffer::clear` to get the `UnicodeBuffer` back
+/// without allocating a new one.
+///
+/// It is up to the caller to ensure that the shape plan matches the properties of the provided
+/// buffer, otherwise the shaping result will likely be incorrect.
+///
+/// # Panics
+///
+/// Will panic when debugging assertions are enabled if the buffer and plan have mismatched
+/// properties.
+pub fn shape_with_plan(face: &Face, plan: &ShapePlan, mut buffer: UnicodeBuffer) -> GlyphBuffer {
+    buffer.guess_segment_properties();
+
     let mut buffer = buffer.0;
     buffer.guess_segment_properties();
 
-    if buffer.len > 0 {
-        let plan = ShapePlan::new(
-            face,
-            buffer.direction,
-            buffer.script,
-            buffer.language.as_ref(),
-            features,
-        );
+    debug_assert_eq!(buffer.direction, plan.direction);
+    debug_assert_eq!(
+        buffer.script.unwrap_or(script::UNKNOWN),
+        plan.script.unwrap_or(script::UNKNOWN)
+    );
 
+    if buffer.len > 0 {
         // Save the original direction, we use it later.
         let target_direction = buffer.direction;
         shape_internal(&mut ShapeContext {
-            plan: &plan,
+            plan,
             face,
             buffer: &mut buffer,
-            user_features: features,
             target_direction,
         });
     }
@@ -44,7 +69,6 @@ struct ShapeContext<'a> {
     plan: &'a ShapePlan,
     face: &'a Face<'a>,
     buffer: &'a mut Buffer,
-    user_features: &'a [Feature],
     // Transient stuff
     target_direction: Direction,
 }
@@ -253,7 +277,7 @@ fn setup_masks(ctx: &mut ShapeContext) {
         func(ctx.plan, ctx.face, ctx.buffer);
     }
 
-    for feature in ctx.user_features {
+    for feature in &ctx.plan.user_features {
         if !feature.is_global() {
             let (mask, shift) = ctx.plan.ot_map.mask(feature.tag);
             ctx.buffer


### PR DESCRIPTION
This exposes `ShapePlan` outside of the `rustybuzz` crate, and provides a new `shape_with_plan` function that takes in a `ShapePlan` instead of a list of user features.

Callers are expected to properly cache `ShapePlan`s to avoid incorrect rendering due to mismatches between the `ShapePlan` and the provided buffer.  To help avoid bugs due to mismatches, I added two `debug_assert!()` lines to verify that the plan and buffer use the same direction and script.

Given that `ShapePlan` is now public outside of the crate, I changed a number of `pub` specifiers to `pub(crate)` to maintain the same effective visibility.