### PR TITLE
Derive `Hash` for `Feature`

### DIFF
--- a/src/common.rs
+++ b/src/common.rs
@@ -451,7 +451,7 @@ pub mod script {
 /// `shape`s input it should be applied.
 #[repr(C)]
 #[allow(missing_docs)]
-#[derive(Clone, Copy, PartialEq, Debug)]
+#[derive(Clone, Copy, PartialEq, Hash, Debug)]
 pub struct Feature {
     pub tag: Tag,
     pub value: u32,


### PR DESCRIPTION
This makes it easier to cache a shape plan because the features would typically be part of a cache key.