### PR TITLE
Make shape plan `Send` and `Sync`

### DIFF
--- a/src/complex/mod.rs
+++ b/src/complex/mod.rs
@@ -74,7 +74,7 @@ pub struct ComplexShaper {
 
     /// Called at the end of `shape_plan()`.
     /// Whatever shapers return will be accessible through `plan.data()` later.
-    pub create_data: Option<fn(&ShapePlan) -> Box<dyn Any>>,
+    pub create_data: Option<fn(&ShapePlan) -> Box<dyn Any + Send + Sync>>,
 
     /// Called during `shape()`.
     /// Shapers can use to modify text before shaping starts.

--- a/src/plan.rs
+++ b/src/plan.rs
@@ -13,7 +13,7 @@ pub struct ShapePlan {
     pub(crate) shaper: &'static ComplexShaper,
     pub(crate) ot_map: ot::Map,
     pub(crate) aat_map: aat::Map,
-    data: Option<Box<dyn Any>>,
+    data: Option<Box<dyn Any + Send + Sync>>,
 
     pub(crate) frac_mask: Mask,
     pub(crate) numr_mask: Mask,
@@ -361,5 +361,16 @@ impl<'a> ShapePlanner<'a> {
         }
 
         plan
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::ShapePlan;
+
+    #[test]
+    fn test_shape_plan_is_send_and_sync() {
+        fn ensure_send_and_sync<T: Send + Sync>() {}
+        ensure_send_and_sync::<ShapePlan>();
     }
 }


### PR DESCRIPTION
With this trivial change a single shape plan can be used from multiple threads.