### PR TITLE
Bump Rust Edition

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "rustybuzz"
 version = "0.13.0"
 authors = ["Evgeniy Reizner <razrfalcon@gmail.com>"]
-edition = "2018"
+edition = "2021"
 description = "A complete harfbuzz shaping algorithm port to Rust."
 documentation = "https://docs.rs/rustybuzz/"
 readme = "README.md"


### PR DESCRIPTION
I ran `cargo fix --edition --all-features` and nothing changed. The tests also all still passed on both the master and my 4.3.0 branch