### PR TITLE
Sync to 7.3.0

### DIFF
--- a/src/hb/common.rs
+++ b/src/hb/common.rs
@@ -144,7 +144,8 @@ impl Direction {
             // https://github.com/harfbuzz/harfbuzz/issues/1000
             script::OLD_HUNGARIAN |
             script::OLD_ITALIC |
-            script::RUNIC => {
+            script::RUNIC |
+            script::TIFINAGH => {
                 None
             }
 

--- a/src/hb/ot/layout/GPOS/mark_base_pos.rs
+++ b/src/hb/ot/layout/GPOS/mark_base_pos.rs
@@ -31,7 +31,8 @@ impl Apply for MarkToBaseAdjustment<'_> {
         while j > ctx.last_base_until as usize {
             let mut _match = iter.match_(&buffer.info[j - 1]);
             if _match == match_t::MATCH {
-                if !accept(buffer, j - 1) {
+                // https://github.com/harfbuzz/harfbuzz/issues/4124
+                if !accept(buffer, j - 1) && !self.base_coverage.contains(buffer.info[j - 1].as_glyph()) {
                     _match = match_t::SKIP;
                 }
             }

--- a/src/hb/ot/layout/GPOS/mark_base_pos.rs
+++ b/src/hb/ot/layout/GPOS/mark_base_pos.rs
@@ -32,7 +32,9 @@ impl Apply for MarkToBaseAdjustment<'_> {
             let mut _match = iter.match_(&buffer.info[j - 1]);
             if _match == match_t::MATCH {
                 // https://github.com/harfbuzz/harfbuzz/issues/4124
-                if !accept(buffer, j - 1) && !self.base_coverage.contains(buffer.info[j - 1].as_glyph()) {
+                if !accept(buffer, j - 1)
+                    && !self.base_coverage.contains(buffer.info[j - 1].as_glyph())
+                {
                     _match = match_t::SKIP;
                 }
             }

--- a/src/hb/ot/layout/GPOS/mark_lig_pos.rs
+++ b/src/hb/ot/layout/GPOS/mark_lig_pos.rs
@@ -26,8 +26,6 @@ impl Apply for MarkToLigatureAdjustment<'_> {
         while j > ctx.last_base_until as usize {
             let mut _match = iter.match_(&buffer.info[j - 1]);
             if _match == match_t::MATCH {
-                // Due to borrow checker, we cannot assign directly to ctx.last_base in the
-                // for loop, unlike in harfbuzz.
                 ctx.last_base = j as i32 - 1;
                 break;
             }

--- a/src/hb/ot/layout/GPOS/mark_lig_pos.rs
+++ b/src/hb/ot/layout/GPOS/mark_lig_pos.rs
@@ -23,21 +23,15 @@ impl Apply for MarkToLigatureAdjustment<'_> {
         iter.set_lookup_props(u32::from(lookup_flags::IGNORE_MARKS));
 
         let mut j = buffer.idx;
-        let mut new_last_base = None;
         while j > ctx.last_base_until as usize {
             let mut _match = iter.match_(&buffer.info[j - 1]);
             if _match == match_t::MATCH {
                 // Due to borrow checker, we cannot assign directly to ctx.last_base in the
                 // for loop, unlike in harfbuzz.
-                new_last_base = Some(j as i32 - 1);
+                ctx.last_base = j as i32 - 1;
                 break;
             }
             j -= 1;
-        }
-        let iter_idx = iter.index();
-
-        if let Some(last_base) = new_last_base {
-            ctx.last_base = last_base;
         }
 
         ctx.last_base_until = buffer.idx as u32;
@@ -48,14 +42,14 @@ impl Apply for MarkToLigatureAdjustment<'_> {
             return None;
         }
 
-        j = ctx.last_base as usize;
+        let idx = ctx.last_base as usize;
 
         // Checking that matched glyph is actually a ligature by GDEF is too strong; disabled
 
-        let lig_glyph = buffer.info[j].as_glyph();
+        let lig_glyph = buffer.info[idx].as_glyph();
         let Some(lig_index) = self.ligature_coverage.get(lig_glyph) else {
             ctx.buffer
-                .unsafe_to_concat_from_outbuffer(Some(iter_idx), Some(buffer.idx + 1));
+                .unsafe_to_concat_from_outbuffer(Some(idx), Some(buffer.idx + 1));
             return None;
         };
         let lig_attach = self.ligature_array.get(lig_index)?;
@@ -64,7 +58,7 @@ impl Apply for MarkToLigatureAdjustment<'_> {
         let comp_count = lig_attach.rows;
         if comp_count == 0 {
             ctx.buffer
-                .unsafe_to_concat_from_outbuffer(Some(iter_idx), Some(buffer.idx + 1));
+                .unsafe_to_concat_from_outbuffer(Some(idx), Some(buffer.idx + 1));
             return None;
         }
 
@@ -72,7 +66,7 @@ impl Apply for MarkToLigatureAdjustment<'_> {
         // is identical to the ligature ID of the found ligature.  If yes, we
         // can directly use the component index.  If not, we attach the mark
         // glyph to the last component of the ligature.
-        let lig_id = _hb_glyph_info_get_lig_id(&buffer.info[j]);
+        let lig_id = _hb_glyph_info_get_lig_id(&buffer.info[idx]);
         let mark_id = _hb_glyph_info_get_lig_id(&buffer.cur(0));
         let mark_comp = u16::from(_hb_glyph_info_get_lig_comp(buffer.cur(0)));
         let matches = lig_id != 0 && lig_id == mark_id && mark_comp > 0;
@@ -82,6 +76,7 @@ impl Apply for MarkToLigatureAdjustment<'_> {
             comp_count
         } - 1;
 
-        self.marks.apply(ctx, lig_attach, mark_index, comp_index, j)
+        self.marks
+            .apply(ctx, lig_attach, mark_index, comp_index, idx)
     }
 }

--- a/src/hb/ot/layout/GPOS/pair_pos.rs
+++ b/src/hb/ot/layout/GPOS/pair_pos.rs
@@ -54,10 +54,12 @@ impl Apply for PairAdjustment<'_> {
         let bail = |ctx: &mut hb_ot_apply_context_t,
                     iter_index: &mut usize,
                     records: (ValueRecord, ValueRecord)| {
-            let flag1 = records.0.apply(ctx, ctx.buffer.idx);
-            let flag2 = records.1.apply(ctx, second_glyph_index);
-
+            let has_record1 = !records.0.is_empty();
             let has_record2 = !records.1.is_empty();
+
+            let flag1 = has_record1 && records.0.apply(ctx, ctx.buffer.idx);
+            let flag2 = has_record2 && records.1.apply(ctx, second_glyph_index);
+
             success(ctx, iter_index, flag1, flag2, has_record2)
         };
 

--- a/src/hb/ot/layout/GSUB/ligature_set.rs
+++ b/src/hb/ot/layout/GSUB/ligature_set.rs
@@ -16,5 +16,9 @@ impl Apply for LigatureSet<'_> {
             }
         }
         None
+
+        // TODO: port https://github.com/harfbuzz/harfbuzz/commit/7881eadff and
+        // the following commits. Since it's behind a feature flag, we ignore it
+        // for now and just use the simpler version.
     }
 }

--- a/src/hb/ot_layout_gsubgpos.rs
+++ b/src/hb/ot_layout_gsubgpos.rs
@@ -181,6 +181,10 @@ pub fn match_lookahead(
 
 pub type match_func_t<'a> = dyn Fn(GlyphId, u16) -> bool + 'a;
 
+// TODO: In harfbuzz, these properties are part of the `matcher_t` struct, but here
+// they are all straight in skipping iterator. There are also some other differences,
+// such as that we don't have a `per_syllable` flag as well as no init() and iter() functions
+// for the skippy iterator. Investigate and align more with harfbuzz, if possible.
 pub struct skipping_iterator_t<'a, 'b> {
     ctx: &'a hb_ot_apply_context_t<'a, 'b>,
     lookup_props: u32,

--- a/src/hb/ot_layout_gsubgpos.rs
+++ b/src/hb/ot_layout_gsubgpos.rs
@@ -65,10 +65,8 @@ pub fn match_input(
     let first = ctx.buffer.cur(0);
     let first_lig_id = _hb_glyph_info_get_lig_id(first);
     let first_lig_comp = _hb_glyph_info_get_lig_comp(first);
-    let mut total_component_count = _hb_glyph_info_get_lig_num_comps(first);
+    let mut total_component_count = 0;
     let mut ligbase = Ligbase::NotChecked;
-
-    match_positions[0] = ctx.buffer.idx;
 
     for position in &mut match_positions[1..count] {
         let mut unsafe_to = 0;
@@ -129,8 +127,11 @@ pub fn match_input(
     *end_position = iter.index() + 1;
 
     if let Some(p_total_component_count) = p_total_component_count {
+        total_component_count += _hb_glyph_info_get_lig_num_comps(first);
         *p_total_component_count = total_component_count;
     }
+
+    match_positions[0] = ctx.buffer.idx;
 
     true
 }

--- a/src/hb/ot_shape.rs
+++ b/src/hb/ot_shape.rs
@@ -629,7 +629,11 @@ fn set_unicode_props(buffer: &mut hb_buffer_t) {
     }
 }
 
-pub(crate) fn syllabic_clear_var(_: &hb_ot_shape_plan_t, _: &hb_font_t, buffer: &mut hb_buffer_t) -> bool {
+pub(crate) fn syllabic_clear_var(
+    _: &hb_ot_shape_plan_t,
+    _: &hb_font_t,
+    buffer: &mut hb_buffer_t,
+) -> bool {
     for info in &mut buffer.info {
         info.set_syllable(0);
     }

--- a/src/hb/ot_shape.rs
+++ b/src/hb/ot_shape.rs
@@ -629,6 +629,14 @@ fn set_unicode_props(buffer: &mut hb_buffer_t) {
     }
 }
 
+pub(crate) fn syllabic_clear_var(_: &hb_ot_shape_plan_t, _: &hb_font_t, buffer: &mut hb_buffer_t) -> bool {
+    for info in &mut buffer.info {
+        info.set_syllable(0);
+    }
+
+    false
+}
+
 fn insert_dotted_circle(buffer: &mut hb_buffer_t, face: &hb_font_t) {
     if !buffer
         .flags

--- a/src/hb/ot_shaper_indic.rs
+++ b/src/hb/ot_shaper_indic.rs
@@ -625,7 +625,7 @@ fn override_features(planner: &mut hb_ot_shape_planner_t) {
     planner
         .ot_map
         .disable_feature(hb_tag_t::from_bytes(b"liga"));
-    planner.ot_map.add_gsub_pause(None);
+    planner.ot_map.add_gsub_pause(Some(syllabic_clear_var)); // Don't need syllables anymore.
 }
 
 fn preprocess_text(_: &hb_ot_shape_plan_t, _: &hb_font_t, buffer: &mut hb_buffer_t) {

--- a/src/hb/ot_shaper_indic.rs
+++ b/src/hb/ot_shaper_indic.rs
@@ -1441,10 +1441,17 @@ fn final_reordering_impl(
                                 base += 1;
                             }
 
-                            buffer.info[base].set_indic_position(ot_position_t::POS_BASE_C);
+                            if base < end {
+                                buffer.info[base].set_indic_position(ot_position_t::POS_BASE_C);
+                            }
+
                             try_pref = false;
                         }
 
+                        break;
+                    }
+
+                    if base == end {
                         break;
                     }
                 }

--- a/src/hb/ot_shaper_khmer.rs
+++ b/src/hb/ot_shaper_khmer.rs
@@ -121,7 +121,7 @@ fn collect_features(planner: &mut hb_ot_shape_planner_t) {
     }
 
     /* https://github.com/harfbuzz/harfbuzz/issues/3531 */
-    planner.ot_map.add_gsub_pause(None);
+    planner.ot_map.add_gsub_pause(Some(syllabic_clear_var)); // Don't need syllables anymore.
 
     for feature in KHMER_FEATURES.iter().skip(5) {
         planner.ot_map.add_feature(feature.0, feature.1, 1);

--- a/src/hb/ot_shaper_myanmar.rs
+++ b/src/hb/ot_shaper_myanmar.rs
@@ -88,7 +88,7 @@ fn collect_features(planner: &mut hb_ot_shape_planner_t) {
         planner.ot_map.add_gsub_pause(None);
     }
 
-    planner.ot_map.add_gsub_pause(None);
+    planner.ot_map.add_gsub_pause(Some(syllabic_clear_var)); // Don't need syllables anymore.
 
     for feature in MYANMAR_FEATURES.iter().skip(4) {
         planner

--- a/src/hb/ot_shaper_use.rs
+++ b/src/hb/ot_shaper_use.rs
@@ -223,7 +223,7 @@ fn collect_features(planner: &mut hb_ot_shape_planner_t) {
     }
 
     planner.ot_map.add_gsub_pause(Some(reorder_use));
-    planner.ot_map.add_gsub_pause(None);
+    planner.ot_map.add_gsub_pause(Some(syllabic_clear_var)); // Don't need syllables anymore.
 
     // Topographical features
     for feature in TOPOGRAPHICAL_FEATURES {


### PR DESCRIPTION
A couple of points I wasn't sure about / need to discuss, but other than that nothing crazy, luckily:

| Status | Commit message                                             | HB                                                            |                                                                                                 |
| ------ | ---------------------------------------------------------- | ------------------------------------------------------------- | ----------------------------------------------------------------------------------------------- |
| 🟢     | [MarkBase] Adjust base-finding logic                       | [Link](https://github.com/harfbuzz/harfbuzz/commit/adccc5355) |                                                                                                 |
| 🟢     | [GPOS] Fix indexing in MarkLigPos                          | [Link](https://github.com/harfbuzz/harfbuzz/commit/c67c0086e) |                                                                                                 |
| 🟡     | [GSUB] Support SingleSubst in get_glyph_alternates         | [Link](https://github.com/harfbuzz/harfbuzz/commit/7327006d6) | I guess not relevant? seems more like an API thing, not actually relevant for shaping           |
| 🟢     | Add Tifinagh to list of both-directions scripts            | [Link](https://github.com/harfbuzz/harfbuzz/commit/2d8634624) |                                                                                                 |
| 🟢     | [indic] Tighten up base-finding                            | [Link](https://github.com/harfbuzz/harfbuzz/commit/453ded053) |                                                                                                 |
| 🟢     | [syllabic] Actually clear syllables                        | [Link](https://github.com/harfbuzz/harfbuzz/commit/c5f3b3feb) |                                                                                                 |
| 🟡     | [syllabic] Better fix for previous issue                   | [Link](https://github.com/harfbuzz/harfbuzz/commit/63afb4f2e) | unsure about this one, our skippy iter only has syllable but not a bool "per_syllable">         |
| 🟢     | [match_input] Micro-optimize                               | [Link](https://github.com/harfbuzz/harfbuzz/commit/49ac5e11e) |                                                                                                 |
| 🟢     | [PairPos2] Micro-optimize                                  | [Link](https://github.com/harfbuzz/harfbuzz/commit/599671543) |                                                                                                 |
| 🟡     | [PairPosFormat2] Micro-optimize and don't kern if class2=0 | [Link](https://github.com/harfbuzz/harfbuzz/commit/95f155573) | not sure I can really port this... I remember we ported this in the past and it was a huge pain because ttf-parser doesn't give that much low-level access |
| 🟡     | [Ligature] Speed up                                        | [Link](https://github.com/harfbuzz/harfbuzz/commit/7881eadff) | do we need to port this since it's behind a compilation flag? probably easier to ignore it      |
| 🟡     | [Ligature] Minor tweak to recent code                      | [Link](https://github.com/harfbuzz/harfbuzz/commit/51061d285) |                                                                                                 |
| 🟡     | [Ligature] Micro-optimize                                  | [Link](https://github.com/harfbuzz/harfbuzz/commit/0fe90ebc0) |                                                                                                 |
| 🟡     | [Ligature] Micro-optimize more                             | [Link](https://github.com/harfbuzz/harfbuzz/commit/ddd6c2e7a) | same as above                                                                                   |
| 🟡     | [Ligature] Use slow path if 2 or fewer ligatures           | [Link](https://github.com/harfbuzz/harfbuzz/commit/ae0fe02d1) |                                                                                                 |
| 🟡     | [GPOS] Optimize iterator reset                             | [Link](https://github.com/harfbuzz/harfbuzz/commit/fb795dc3c) | we dont have the whole iter thing with init and reset right?                                    |
| 🟡     | [layout] Don't init iters successively multiple times      | [Link](https://github.com/harfbuzz/harfbuzz/commit/3f2401e2f) | same                                                                                            |